### PR TITLE
Fix the new messages indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-web",
-  "version": "1.0.0-alpha-4-dev",
+  "version": "1.0.0-alpha-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List } from 'react-virtualized'
 import classNames from 'classnames'
@@ -19,6 +19,7 @@ function MessageList ({
   onMessageInView,
   loading,
   replicating,
+  hasUnreadMessages,
   useLargeMessage,
   useMonospaceFont,
   ...messageRowProps
@@ -174,18 +175,28 @@ function MessageList ({
       {({ height, width }) => {
         if (width !== listWidth) setListWidth(width)
         return (
-          <List
-            className={classNames('MessageList', { notAtBottom: !atBottom })}
-            ref={list}
-            width={width}
-            height={height}
-            rowCount={messages.length}
-            deferredMeasurementCache={rowHeightCache}
-            rowHeight={rowHeightCache.rowHeight}
-            rowRenderer={rowRenderer}
-            onRowsRendered={onRowsRendered}
-            noRowsRenderer={LoadingOrFirstMessage.bind(null, { loading, channelName })}
-          />
+          <Fragment>
+            <List
+              className="MessageList"
+              ref={list}
+              width={width}
+              height={height}
+              rowCount={messages.length}
+              deferredMeasurementCache={rowHeightCache}
+              rowHeight={rowHeightCache.rowHeight}
+              rowRenderer={rowRenderer}
+              onRowsRendered={onRowsRendered}
+              noRowsRenderer={LoadingOrFirstMessage.bind(null, { loading, channelName })}
+            />
+            <div
+              className={classNames('unreadIndicator', {
+                hidden: !loading && (atBottom || !hasUnreadMessages),
+                loading: loading || replicating
+              })}
+            >
+              <div className="progressBar" />
+            </div>
+          </Fragment>
         )
       }}
     </AutoSizer>
@@ -199,6 +210,7 @@ MessageList.propTypes = {
   onMessageInView: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   replicating: PropTypes.bool,
+  hasUnreadMessages: PropTypes.bool,
   useLargeMessage: PropTypes.bool,
   useMonospaceFont: PropTypes.bool
 }

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -172,12 +172,6 @@ function MessageList ({
     parent: PropTypes.node.isRequired
   }
 
-  const statusIndicator = (
-    <div className="unreadIndicator loading">
-      <div className="progressBar" />
-    </div>
-  )
-
   return (
     <AutoSizer onResize={onListSizeChange}>
       {({ height, width }) => {
@@ -196,14 +190,14 @@ function MessageList ({
               onRowsRendered={onRowsRendered}
               noRowsRenderer={LoadingOrFirstMessage.bind(null, { loading, channelName })}
             />
-            <Suspense fallback={statusIndicator} delay={500} loading={loading || replicating}>
-              <div
-                className={classNames('unreadIndicator', {
-                  hidden: !loading && !replicating && (atBottom || !hasUnreadMessages)
-                })}
-              >
-                <div className="progressBar" />
-              </div>
+            <Suspense
+              key={`status-indicator-${messages.length}`}
+              fallback={<div className="progressBar" />}
+              delay={500}
+              loading={loading || replicating}
+              passThrough={true}
+            >
+              {!atBottom && hasUnreadMessages ? <div className="unreadIndicator" /> : null}
             </Suspense>
           </Fragment>
         )

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -191,7 +191,7 @@ function MessageList ({
             <div
               className={classNames('unreadIndicator', {
                 hidden: !loading && (atBottom || !hasUnreadMessages),
-                loading: loading || replicating
+                loading: loading
               })}
             >
               <div className="progressBar" />

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -6,6 +6,8 @@ import { AutoSizer, CellMeasurer, CellMeasurerCache, List } from 'react-virtuali
 import classNames from 'classnames'
 import debounce from 'lodash.debounce'
 
+import Suspense from '../components/Suspense'
+
 import MessageRow from '../components/MessageRow'
 import MessagesDateSeparator from '../components/MessagesDateSeparator'
 import { LoadingOrFirstMessage } from '../components/MessageTypes'
@@ -170,6 +172,12 @@ function MessageList ({
     parent: PropTypes.node.isRequired
   }
 
+  const statusIndicator = (
+    <div className="unreadIndicator loading">
+      <div className="progressBar" />
+    </div>
+  )
+
   return (
     <AutoSizer onResize={onListSizeChange}>
       {({ height, width }) => {
@@ -188,14 +196,15 @@ function MessageList ({
               onRowsRendered={onRowsRendered}
               noRowsRenderer={LoadingOrFirstMessage.bind(null, { loading, channelName })}
             />
-            <div
-              className={classNames('unreadIndicator', {
-                hidden: !loading && (atBottom || !hasUnreadMessages),
-                loading: loading
-              })}
-            >
-              <div className="progressBar" />
-            </div>
+            <Suspense fallback={statusIndicator} delay={500} loading={loading || replicating}>
+              <div
+                className={classNames('unreadIndicator', {
+                  hidden: !loading && !replicating && (atBottom || !hasUnreadMessages)
+                })}
+              >
+                <div className="progressBar" />
+              </div>
+            </Suspense>
           </Fragment>
         )
       }}

--- a/src/components/Suspense.js
+++ b/src/components/Suspense.js
@@ -28,7 +28,13 @@ function Suspense (props) {
     if (props.loading && typeof props.callback === 'function') props.callback()
   }, props.delay)
 
-  return !props.loading ? props.children : displayFallback ? props.fallback : null
+  return !props.loading
+    ? props.children
+    : displayFallback
+      ? props.fallback
+      : props.passThrough
+        ? props.children
+        : null
 }
 
 export default Suspense

--- a/src/containers/ChannelControls.js
+++ b/src/containers/ChannelControls.js
@@ -9,7 +9,6 @@ import Logger from '../utils/logger'
 import RootStoreContext from '../context/RootStoreContext'
 
 import FileUploadButton from '../components/FileUploadButton'
-import Spinner from '../components/Spinner'
 
 import ChannelStatus from './ChannelStatus'
 import SendMessage from './SendMessage'
@@ -41,7 +40,6 @@ function ChannelControls ({ channel }) {
     <Observer>
       {() => (
         <div className="Controls">
-          <Spinner loading={channel.loading || channel.replicating || channel.sendingMessage} />
           <SendMessage
             onSendMessage={sendMessage}
             theme={uiStore.theme}

--- a/src/containers/ChannelMessages.js
+++ b/src/containers/ChannelMessages.js
@@ -35,6 +35,7 @@ function ChannelMessages ({ channel }) {
         channelName={channel.channelName}
         loading={channel.loading}
         replicating={channel.replicating}
+        hasUnreadMessages={channel.hasUnreadMessages}
         highlightWords={[sessionStore.username]}
         loadFile={channel.loadFile}
         useLargeMessage={uiStore.useLargeMessage}

--- a/src/styles/Animations.scss
+++ b/src/styles/Animations.scss
@@ -227,3 +227,45 @@ $bounce-amount: 2px;
         opacity: 0;
     }
 }
+
+@mixin keyframes($animation-name) {
+    @-webkit-keyframes #{$animation-name} {
+        @content;
+    }
+    @-moz-keyframes #{$animation-name} {
+        @content;
+    }
+    @keyframes #{$animation-name} {
+        @content;
+    }
+}
+
+@include keyframes(indeterminate) {
+    0% {
+        left: -35%;
+        right:100%;
+    }
+    60% {
+        left: 100%;
+        right: -90%;
+    }
+    100% {
+        left: 100%;
+        right: -90%;
+    }
+}
+
+@include keyframes(indeterminate-short) {
+    0% {
+        left: -200%;
+        right: 100%;
+    }
+    60% {
+        left: 107%;
+        right: -8%;
+    }
+    100% {
+        left: 107%;
+        right: -8%;
+    }
+}

--- a/src/styles/Channel.scss
+++ b/src/styles/Channel.scss
@@ -343,35 +343,34 @@ input[type="button"],
     height: 2px;
     width: 100%;
     background: $second-color;
-    .progressBar {
-      display: none;
+  }
+
+  .progressBar {
+    position: absolute;
+    bottom: 0;
+    height: 2px;
+    width: 100%;
+    background: $second-color;
+    &:before {
+      content: '';
+      position: absolute;
+      background-color: rgba($second-color, 1);
+      top: 0;
+      left:0;
+      bottom: 0;
+      will-change: left, right;
+      animation: indeterminate 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
     }
-    &.loading {
-      .progressBar {
-        display: block;
-        background: rgba($second-color, 1);
-        &:before {
-          content: '';
-          position: absolute;
-          background-color: inherit;
-          top: 0;
-          left:0;
-          bottom: 0;
-          will-change: left, right;
-          animation: indeterminate 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
-        }
-        &:after {
-          content: '';
-          position: absolute;
-          background-color: inherit;
-          top: 0;
-          left:0;
-          bottom: 0;
-          will-change: left, right;
-          animation: indeterminate-short 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
-          animation-delay: 1.15s;
-        }
-      }
+    &:after {
+      content: '';
+      position: absolute;
+      background-color: rgba($second-color, 1);;
+      top: 0;
+      left:0;
+      bottom: 0;
+      will-change: left, right;
+      animation: indeterminate-short 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
+      animation-delay: 1.15s;
     }
   }
 }

--- a/src/styles/Channel.scss
+++ b/src/styles/Channel.scss
@@ -61,7 +61,6 @@ $controls-height: 2.8em;
   }
 }
 
-
 .dimmed {
   opacity: 0.5;
 }
@@ -285,7 +284,6 @@ input[type="button"],
     padding: 0.5em;
     user-select: none;
     cursor: default;
-
   }
 
   .loadingMessages {
@@ -334,21 +332,47 @@ input[type="button"],
     }
   }
 
-  &:focus, :focus {
+  &:focus,
+  :focus {
     outline: none;
   }
 
-  .MessageList {
-    // padding-bottom: 2px;
-
-    &.notAtBottom {
-      border-bottom: 2px solid $second-color;
-      // padding-bottom: 0;
+  .unreadIndicator {
+    position: absolute;
+    bottom: 0;
+    height: 2px;
+    width: 100%;
+    background: $second-color;
+    .progressBar {
+      display: none;
     }
-
-    &.hasOlderUnreadMessages {}
-
-    &.hasNewerUnreadMessages {}
+    &.loading {
+      .progressBar {
+        display: block;
+        background: rgba($second-color, 1);
+        &:before {
+          content: '';
+          position: absolute;
+          background-color: inherit;
+          top: 0;
+          left:0;
+          bottom: 0;
+          will-change: left, right;
+          animation: indeterminate 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
+        }
+        &:after {
+          content: '';
+          position: absolute;
+          background-color: inherit;
+          top: 0;
+          left:0;
+          bottom: 0;
+          will-change: left, right;
+          animation: indeterminate-short 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
+          animation-delay: 1.15s;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This pull request fixes the issue on small screens in which the replicating/loading indicator spinner is rendered on top of the message input field by moving its functionality to the new messages bar. In short, the new messages bar whenever not on the bottom of the messages reacts to loading with animation and only shows up if there are unread messages.

Fixes #85,
fixes #89