### PR TITLE
Fix Spinner component / Loadable logic

### DIFF
--- a/src/components/Loadable.js
+++ b/src/components/Loadable.js
@@ -1,17 +1,35 @@
 'use strict'
 
+import React from 'react'
+
 import Loadable from 'react-loadable'
 import Spinner from './Spinner'
 
-const LoadAsync = opts =>
-  Loadable(
+function Loading (props) {
+  if (props.error) {
+    console.error('Error while loading component')
+    return null
+  } else if (props.timedOut) {
+    console.error('Timeout while loading component')
+    return null
+  } else if (props.pastDelay) {
+    return <Spinner />
+  } else {
+    return null
+  }
+}
+
+function LoadAsync (opts) {
+  return Loadable(
     Object.assign(
       {
-        loading: Spinner,
-        delay: 300
+        loading: Loading,
+        delay: 200,
+        timeout: 10000
       },
       opts
     )
   )
+}
 
 export default LoadAsync

--- a/src/components/Loadable.js
+++ b/src/components/Loadable.js
@@ -8,8 +8,7 @@ const LoadAsync = opts =>
     Object.assign(
       {
         loading: Spinner,
-        delay: 200,
-        timeout: 10000
+        delay: 300
       },
       opts
     )

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -1,7 +1,10 @@
-@import 'Animations';
-@import 'Colors';
+@import "Animations";
+@import "Colors";
 
-textarea, input { outline: none; }
+textarea,
+input {
+  outline: none;
+}
 
 ::placeholder {
   color: $placeholder-color;
@@ -29,14 +32,22 @@ $channel-name-min-height: 1.5em;
 
 .headerAnimation-appear {
   animation: fadeInDown;
-  animation-duration: .2s;
+  animation-duration: 0.2s;
   animation-fill-mode: both;
   animation-timing-function: ease-out;
 }
 
 .joinChannelAnimation-appear {
   animation: fadeIn;
-  animation-duration: .5s;
+  animation-duration: 0.5s;
   animation-fill-mode: both;
   animation-timing-function: ease-in;
+}
+
+.spinner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
Especially on slow connections, users saw sometimes a spinner that looked off, because the spinner's width was 100% with position: absolute. Removed timeout from Loadable and fixed the CSS to always show the spinner in the same size.

Fixes #97 