### PR TITLE
Allow subdomain gateway to use http

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import './styles/Fonts.scss'
 import './styles/Main.scss'
 import './styles/flaticon.css'
 
-redirectToHttps(!(window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'))
+redirectToHttps(!(window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1' || window.location.hostname === 'orbit.chat.ipns.localhost'))
 
 const App = React.lazy(() => import(/* webpackChunkName: "App" */ './views/App'))
 


### PR DESCRIPTION
go-ipfs 0.5.0 can use a subdomain as gateway to preserve origin security. This updates orbit.chat to be able to load without an https error.